### PR TITLE
Fix FP8 round-trip example on non-native GPUs

### DIFF
--- a/HIP-Doc/Reference/Low-Precision-Floating-Point-Types/low_precision_float_fp8/README.md
+++ b/HIP-Doc/Reference/Low-Precision-Floating-Point-Types/low_precision_float_fp8/README.md
@@ -8,7 +8,7 @@ the
 
 ### Application flow
 
-1. Query the GPU device properties and check for a supported GPU architecture.
+1. Query the GPU device properties and select the FP8 interpretation for the GPU architecture.
 2. On the host side:
    1. Create an input vector and an output vector consisting of 32-bit floating-point numbers.
    2. Initialize the input vector.
@@ -39,8 +39,11 @@ the
   synchronizes the device with the host, ensuring that all kernels queued before the call finish executing before the
   transfer begins. The function completes once the copying operation is finished.
 * Use `hipGetErrorString` to convert a HIP error code into a human-readable string.
-* Use `hipGetDeviceProperties` to query the GPU's information and check for a supported GPU architecture.
+* Use `hipGetDeviceProperties` to query the GPU's information and select the appropriate FP8 interpretation.
 * Use `__hip_cvt_float_to_fp8` to convert a 32-bit floating-point number to its 8-bit equivalent.
+* Use `__hip_cvt_fp8_to_halfraw` to convert the raw 8-bit value to half precision before converting it back to a
+  32-bit floating-point number. HIP uses a portable conversion implementation on GPU architectures without native FP8
+  conversion instructions.
 
 ## Demonstrated API calls
 
@@ -50,6 +53,7 @@ the
 
 * `threadIdx`
 * `__hip_cvt_float_to_fp8`
+* `__hip_cvt_fp8_to_halfraw`
 
 #### Host symbols
 
@@ -59,3 +63,4 @@ the
 * `hipMemcpy`
 * `hipFree`
 * `__hip_cvt_float_to_fp8`
+* `__hip_cvt_fp8_to_halfraw`

--- a/HIP-Doc/Reference/Low-Precision-Floating-Point-Types/low_precision_float_fp8/main.hip
+++ b/HIP-Doc/Reference/Low-Precision-Floating-Point-Types/low_precision_float_fp8/main.hip
@@ -45,14 +45,19 @@ __device__ __hip_fp8_storage_t d_convert_float_to_fp8(float in, __hip_fp8_interp
     return __hip_cvt_float_to_fp8(in, sat, interpret);
 }
 
+__host__ __device__ float convert_fp8_to_float(__hip_fp8_storage_t        in,
+                                               __hip_fp8_interpretation_t interpret)
+{
+    return __half(__hip_cvt_fp8_to_halfraw(in, interpret));
+}
+
 __global__ void float_to_fp8_to_float(float *in, __hip_fp8_interpretation_t interpret, __hip_saturation_t sat, float *out, size_t size)
 {
-    int i = threadIdx.x;
+    size_t i = threadIdx.x;
     if (i < size)
     {
         auto fp8 = d_convert_float_to_fp8(in[i], interpret, sat);
-        // Implicit conversion from fp8 to float is defined by HIP runtime
-        out[i] = fp8;
+        out[i]   = convert_fp8_to_float(fp8, interpret);
     }
 }
 
@@ -69,14 +74,6 @@ int main()
     constexpr size_t size = 32;
     hipDeviceProp_t prop;
     hip_check(hipGetDeviceProperties(&prop, 0));
-    bool is_supported = (std::string(prop.gcnArchName).find("gfx94") != std::string::npos); // gfx94x
-    if(!is_supported)
-    {
-        std::cerr << "Need a gfx94x, but found: " << prop.gcnArchName << std::endl;
-        std::cerr << "No device conversions are supported, only host conversions are supported." << std::endl;
-        return EXIT_SUCCESS;
-    }
-
     const __hip_fp8_interpretation_t interpret = (std::string(prop.gcnArchName).find("gfx94") != std::string::npos)
                                                     ? __HIP_E4M3_FNUZ // gfx94x
                                                     : __HIP_E4M3;
@@ -94,8 +91,7 @@ int main()
     for (const auto &fval : in)
     {
         auto fp8 = convert_float_to_fp8(fval, interpret, sat);
-        // Implicit conversion from fp8 to float is defined by HIP runtime
-        cpu_out.push_back(fp8);
+        cpu_out.push_back(convert_fp8_to_float(fp8, interpret));
     }
 
     // GPU convert


### PR DESCRIPTION
## Motivation

The FP8 example currently exits before launching its kernel unless the device is
`gfx94x`. Current HIP headers also provide host/device software conversion paths
when native FP8 conversion instructions are unavailable, so this excludes GPUs
that can execute the example correctly.

The round-trip validation also assigns raw `__hip_fp8_storage_t` bytes directly
to `float`. That compares the numeric value of the encoded byte instead of the
decoded FP8 value.

## Technical Details

- Decode FP8 storage through `__hip_cvt_fp8_to_halfraw` in a shared host/device
  helper.
- Remove the obsolete `gfx94x` early exit while retaining the existing FNUZ
  selection for `gfx94x` and OCP E4M3 elsewhere.
- Use `size_t` for the kernel index to remove the signed/unsigned warning.
- Document the decode helper and the portable fallback behavior.

This change enables correctness coverage; it does not claim native FP8 hardware
acceleration on architectures such as `gfx1100`.

## Test Plan

Test the exact commit on physical `gfx1100`, compare the unmodified baseline,
exercise both Make and CMake builds, validate the complete E4M3 raw-code space
plus a broad float corpus, trace the kernel dispatch, and compile the CI
architecture set.

## Test Result

Tested on two independently selected AMD Radeon Pro W7900D devices (GPU 0 and
GPU 7) with ROCm 7.14.0 / HIP 7.14.60850 in
`rocm/dev-ubuntu-24.04:7.14.0-full-amd64-digest-439edaa8`.

- Baseline: builds with a signed/unsigned warning, then prints `Need a gfx94x`
  and exits without launching the conversion kernel on both devices.
- Patched Make build: warning-free and reports `CPU and GPU round trip convert
  matches` on both devices.
- Patched CMake build: builds and reports the same passing result on both
  devices.
- Independent HIP validation: all 256 E4M3 raw codes and 65,557 deterministic
  float inputs match between host and device on both devices. The known-value
  oracle also passes: `1.1 -> 0x39 -> 1.125`.
- `rocprofv3 --kernel-trace` records one
  `float_to_fp8_to_float(..., unsigned long)` dispatch with a 32-thread workgroup.
- A `-Wall -Wextra -Werror` fat binary builds for the CI set: `gfx908`, `gfx90a`,
  `gfx942`, `gfx950`, `gfx1030`, `gfx1100`, `gfx1101`, `gfx1200`, and `gfx1201`.
- `clang-format` 18, `git diff --check`, and markdownlint pass.

## Added/Updated documentation?

- [x] Yes
- [ ] No, does not apply to this PR.

## Included Visual Studio files?

- [ ] Yes
- [x] No, does not apply to this PR.

## Submission Checklist

- [x] Existing CMake and Make integrations build the updated example.
- [x] No CI workflow change is needed; the example already participates in the
  HIP-Doc build.
- [x] No unsupported-ASIC guard is needed because the HIP header provides the
  portable conversion path used here.
- [x] Reviewed the repository and ROCm pull-request guidelines.
