### PR TITLE
fix: Apply environment variable to hipthread examples

### DIFF
--- a/Libraries/hipThreads/in_one_weekend_raytracer/step3_hipthread_dropin/CMakeLists.txt
+++ b/Libraries/hipThreads/in_one_weekend_raytracer/step3_hipthread_dropin/CMakeLists.txt
@@ -51,4 +51,5 @@ target_link_libraries(${example_name} PRIVATE hipthreads::hipthreads roc::rocthr
 target_include_directories(${example_name} PRIVATE "../../../../Common")
 
 add_test(NAME ${example_name} COMMAND ${example_name})
+set_tests_properties(${example_name} PROPERTIES ENVIRONMENT "HIPTHREADS_VCORES_PER_WGP=1")
 install(TARGETS ${example_name})

--- a/Libraries/hipThreads/in_one_weekend_raytracer/step4_simdize/CMakeLists.txt
+++ b/Libraries/hipThreads/in_one_weekend_raytracer/step4_simdize/CMakeLists.txt
@@ -51,4 +51,5 @@ target_link_libraries(${example_name} PRIVATE hipthreads::hipthreads roc::rocthr
 target_include_directories(${example_name} PRIVATE "../../../../Common")
 
 add_test(NAME ${example_name} COMMAND ${example_name})
+set_tests_properties(${example_name} PROPERTIES ENVIRONMENT "HIPTHREADS_VCORES_PER_WGP=1")
 install(TARGETS ${example_name})

--- a/Libraries/hipThreads/saxpy/step2_hipthread_dropin/CMakeLists.txt
+++ b/Libraries/hipThreads/saxpy/step2_hipthread_dropin/CMakeLists.txt
@@ -51,4 +51,5 @@ target_link_libraries(${example_name} PRIVATE hipthreads::hipthreads roc::rocthr
 target_include_directories(${example_name} PRIVATE "../../../../Common")
 
 add_test(NAME ${example_name} COMMAND ${example_name})
+set_tests_properties(${example_name} PROPERTIES ENVIRONMENT "HIPTHREADS_VCORES_PER_WGP=1")
 install(TARGETS ${example_name})

--- a/Libraries/hipThreads/saxpy/step3_simdize/CMakeLists.txt
+++ b/Libraries/hipThreads/saxpy/step3_simdize/CMakeLists.txt
@@ -51,4 +51,5 @@ target_link_libraries(${example_name} PRIVATE hipthreads::hipthreads roc::rocthr
 target_include_directories(${example_name} PRIVATE "../../../../Common")
 
 add_test(NAME ${example_name} COMMAND ${example_name})
+set_tests_properties(${example_name} PROPERTIES ENVIRONMENT "HIPTHREADS_VCORES_PER_WGP=1")
 install(TARGETS ${example_name})

--- a/Libraries/hipThreads/sparse_mat_mul/step3_hipthread_port/CMakeLists.txt
+++ b/Libraries/hipThreads/sparse_mat_mul/step3_hipthread_port/CMakeLists.txt
@@ -53,4 +53,5 @@ target_compile_definitions(${example_name} PRIVATE EXAMPLE_DATA_DIR="${CMAKE_CUR
 target_include_directories(${example_name} PRIVATE "../../../../Common")
 
 add_test(NAME ${example_name} COMMAND ${example_name})
+set_tests_properties(${example_name} PROPERTIES ENVIRONMENT "HIPTHREADS_VCORES_PER_WGP=1")
 install(TARGETS ${example_name})


### PR DESCRIPTION
## Motivation

Some of the hipthread examples fail to run on certain setups with a timeout on therock nightly builds. For now, the fix is to apply an environment variable to the failing examples.

## Technical Details

Apply environment variable to the ctest construction in the cmake files.

## Test Plan

Test on similar setups with therock nightly release.

## Test Result

Verified on similar setups that reported the issue locally and the fix works.

## Added/Updated documentation?

<!-- Make sure each new example has a README and the root-level README contains all new examples. -->
<!-- New Libraries examples should have a library-level README explaining the dependencies, build process, and supported platforms. -->

- [ ] Yes
- [x] No, does not apply to this PR.

## Included Visual Studio files?

- [ ] Yes
- [x] No, does not apply to this PR.

## Submission Checklist

- [x] New examples contain proper CMake and Make files.
- [x] I have updated relevant CI workflows and the new examples are being built and tested in CI.
- [x] Check and guard against unsupported ASICs if relevant dependent libraries have limited support.
- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
