### PR TITLE
fix: install Programming-Patterns data files alongside binaries (#508)

### DIFF
--- a/.github/workflows/build-rocm-examples-reusable.yml
+++ b/.github/workflows/build-rocm-examples-reusable.yml
@@ -147,6 +147,11 @@ jobs:
         run: |
           cmake --build build -j
 
+      - name: CMake install
+        if: ${{ !cancelled() }}
+        run: |
+          cmake --install build --prefix install
+
       - name: Collect Makefile build artifacts
         if: ${{ !cancelled() }}
         run: |

--- a/.github/workflows/build_applications.yml
+++ b/.github/workflows/build_applications.yml
@@ -54,11 +54,12 @@ jobs:
                   echo "ROCM_PATH=/opt/rocm" >> $GITHUB_ENV
                   echo "LD_LIBRARY_PATH=/opt/rocm/lib:${LD_LIBRARY_PATH}" >> $GITHUB_ENV
                   apt-get autoclean
-          - name: CMake Configure and Build
+          - name: CMake Configure, Build, and Install
             run: |
               cd Applications
               cmake -DGPU_TARGETS="${GPU_TARGETS}" -S . -B build
               cmake --build build -j
+              cmake --install build --prefix install
           - name: Make
             run: |
               cd Applications

--- a/.github/workflows/build_applications_cuda.yml
+++ b/.github/workflows/build_applications_cuda.yml
@@ -73,8 +73,9 @@ jobs:
               make -j
               make install
 
-          - name: Configure and Build
+          - name: Configure, Build, and Install
             run: |
-              cd Applications && mkdir build && cd build
-              cmake -DROCM_EXAMPLES_GPU_LANGUAGE=CUDA ..
-              cmake --build . -j
+              cd Applications
+              cmake -DROCM_EXAMPLES_GPU_LANGUAGE=CUDA -S . -B build
+              cmake --build build -j
+              cmake --install build --prefix install

--- a/.github/workflows/build_hip_basic.yml
+++ b/.github/workflows/build_hip_basic.yml
@@ -50,11 +50,12 @@ jobs:
                   echo "ROCM_PATH=/opt/rocm" >> $GITHUB_ENV
                   echo "LD_LIBRARY_PATH=/opt/rocm/lib:${LD_LIBRARY_PATH}" >> $GITHUB_ENV
                   apt-get autoclean
-          - name: CMake Configure and Build
+          - name: CMake Configure, Build, and Install
             run: |
               cd HIP-Basic
               cmake -DGPU_TARGETS="${GPU_TARGETS}" -S . -B build
               cmake --build build -j
+              cmake --install build --prefix install
           - name: Make
             run: |
               cd HIP-Basic

--- a/.github/workflows/build_hip_basic_cuda.yml
+++ b/.github/workflows/build_hip_basic_cuda.yml
@@ -48,8 +48,9 @@ jobs:
               apt-get update -qq &&
               apt-get install -y hip-dev hipify-clang
 
-          - name: Configure and Build
+          - name: Configure, Build, and Install
             run: |
-              cd HIP-Basic && mkdir build && cd build
-              cmake -DROCM_EXAMPLES_GPU_LANGUAGE=CUDA ..
-              cmake --build . -j
+              cd HIP-Basic
+              cmake -DROCM_EXAMPLES_GPU_LANGUAGE=CUDA -S . -B build
+              cmake --build build -j
+              cmake --install build --prefix install

--- a/.github/workflows/build_hip_documentation.yml
+++ b/.github/workflows/build_hip_documentation.yml
@@ -50,13 +50,14 @@ jobs:
                   echo "ROCM_PATH=/opt/rocm" >> $GITHUB_ENV
                   echo "LD_LIBRARY_PATH=/opt/rocm/lib:${LD_LIBRARY_PATH}" >> $GITHUB_ENV
                   apt-get autoclean
-          - name: CMake Configure and Build
+          - name: CMake Configure, Build, and Install
             # The CMAKE_POLICY_VERSION_MINIMUM environment variable can be removed once the CMake updates from ROCm 7.0 are available
             run: |
               cd HIP-Doc
               export CMAKE_POLICY_VERSION_MINIMUM="3.5"
               cmake -DGPU_TARGETS="${GPU_TARGETS}" -S . -B build
               cmake --build build -j
+              cmake --install build --prefix install
           - name: Make
             run: |
               cd HIP-Doc

--- a/.github/workflows/build_hip_documentation_cuda.yml
+++ b/.github/workflows/build_hip_documentation_cuda.yml
@@ -48,10 +48,11 @@ jobs:
               apt-get update -qq &&
               apt-get install -y hip-dev hipify-clang hipfft-dev
 
-          - name: Configure and Build
+          - name: Configure, Build, and Install
             # The CMAKE_POLICY_VERSION_MINIMUM environment variable can be removed once the CMake updates from ROCm 7.0 are available
             run: |
-              cd HIP-Doc && mkdir build && cd build
+              cd HIP-Doc
               export CMAKE_POLICY_VERSION_MINIMUM="3.5"
-              cmake -DROCM_EXAMPLES_GPU_LANGUAGE=CUDA -DHIP_PLATFORM=nvidia ..
-              cmake --build . -j
+              cmake -DROCM_EXAMPLES_GPU_LANGUAGE=CUDA -DHIP_PLATFORM=nvidia -S . -B build
+              cmake --build build -j
+              cmake --install build --prefix install

--- a/.github/workflows/build_libraries.yml
+++ b/.github/workflows/build_libraries.yml
@@ -58,11 +58,12 @@ jobs:
               fi
               echo "ENABLE_CK=${ENABLE_CK}" >> $GITHUB_ENV
               echo "ROCM_EXAMPLES_ENABLE_CK=${ENABLE_CK}"
-          - name: CMake Configure and Build
+          - name: CMake Configure, Build, and Install
             run: |
               cd Libraries
               cmake -DCMAKE_BUILD_TYPE=Release -DGPU_TARGETS="${GPU_TARGETS}" -DCMAKE_HIP_ARCHITECTURES="${GPU_TARGETS}" -DROCM_EXAMPLES_ENABLE_CK=${ENABLE_CK} -DROCM_EXAMPLES_ENABLE_OPENMP=ON -S . -B build
               cmake --build build --parallel $(nproc)
+              cmake --install build --prefix install
           - name: Make
             run: |
               sed -i '/rocCV/d' Libraries/Makefile

--- a/.github/workflows/build_programming_guide.yml
+++ b/.github/workflows/build_programming_guide.yml
@@ -49,11 +49,12 @@ jobs:
                   echo "ROCM_PATH=/opt/rocm" >> $GITHUB_ENV
                   echo "LD_LIBRARY_PATH=/opt/rocm/lib:${LD_LIBRARY_PATH}" >> $GITHUB_ENV
                   apt-get autoclean
-          - name: CMake Configure and Build
+          - name: CMake Configure, Build, and Install
             run: |
               cd Programming-Guide
               cmake -DCMAKE_HIP_PLATFORM=amd -DCMAKE_HIP_ARCHITECTURES="${GPU_TARGETS}" -S . -B build
               cmake --build build -j
+              cmake --install build --prefix install
           - name: Make
             run: |
               cd Programming-Guide

--- a/.github/workflows/build_programming_guide_cuda.yml
+++ b/.github/workflows/build_programming_guide_cuda.yml
@@ -47,8 +47,9 @@ jobs:
               apt-get update -qq &&
               apt-get install -y hip-dev hipify-clang
 
-          - name: Configure and Build
+          - name: Configure, Build, and Install
             run: |
-              cd Programming-Guide && mkdir build && cd build
-              cmake -DROCM_EXAMPLES_GPU_LANGUAGE=CUDA -DHIP_PLATFORM=nvidia ..
-              cmake --build . -j
+              cd Programming-Guide
+              cmake -DROCM_EXAMPLES_GPU_LANGUAGE=CUDA -DHIP_PLATFORM=nvidia -S . -B build
+              cmake --build build -j
+              cmake --install build --prefix install

--- a/.github/workflows/build_systems.yml
+++ b/.github/workflows/build_systems.yml
@@ -56,11 +56,12 @@ jobs:
                   wget ${{ env.HIPFILE_BASE_URL }}/hipfile-dev_0.2.0.70200-nightly.9999.24.04_amd64.deb
                   apt-get install -y ./hipfile_0.2.0.70200-nightly.9999.24.04_amd64.deb \
                                      ./hipfile-dev_0.2.0.70200-nightly.9999.24.04_amd64.deb
-          - name: CMake Configure and Build
+          - name: CMake Configure, Build, and Install
             run: |
               cd Systems
               cmake -DCMAKE_BUILD_TYPE=Release -DGPU_TARGETS="${GPU_TARGETS}" -DCMAKE_HIP_ARCHITECTURES="${GPU_TARGETS}" -S . -B build
               cmake --build build -j $(nproc)
+              cmake --install build --prefix install
           - name: Make
             run: |
               cd Systems

--- a/.github/workflows/build_systems_cuda.yml
+++ b/.github/workflows/build_systems_cuda.yml
@@ -64,8 +64,9 @@ jobs:
                   apt-get install -y ./hipfile_0.2.0.70200-nightly.9999.24.04_amd64.deb \
                                      ./hipfile-dev_0.2.0.70200-nightly.9999.24.04_amd64.deb
 
-          - name: Configure and Build
+          - name: Configure, Build, and Install
             run: |
-              cd Systems && mkdir build && cd build
-              cmake -DROCM_EXAMPLES_GPU_LANGUAGE=CUDA -DHIP_PLATFORM=nvidia ..
-              cmake --build . -j $(nproc)
+              cd Systems
+              cmake -DROCM_EXAMPLES_GPU_LANGUAGE=CUDA -DHIP_PLATFORM=nvidia -S . -B build
+              cmake --build build -j $(nproc)
+              cmake --install build --prefix install

--- a/.github/workflows/build_tools.yml
+++ b/.github/workflows/build_tools.yml
@@ -52,11 +52,12 @@ jobs:
                   apt-get autoclean
           - name: Install rocprof-compute dependencies
             run: python3 -m pip install -r /opt/rocm/libexec/rocprofiler-compute/requirements.txt
-          - name: CMake Configure and Build
+          - name: CMake Configure, Build, and Install
             run: |
               cd Tools
               cmake -DGPU_TARGETS="${GPU_TARGETS}" -S . -B build
               cmake --build build -j
+              cmake --install build --prefix install
           - name: Make
             run: |
               cd Tools

--- a/HIP-Doc/Tutorials/Programming-Patterns/bfs/CMakeLists.txt
+++ b/HIP-Doc/Tutorials/Programming-Patterns/bfs/CMakeLists.txt
@@ -70,4 +70,4 @@ add_custom_command(TARGET ${example_name} POST_BUILD
 add_test(NAME ${example_name} COMMAND ${example_name} graph4096.txt WORKING_DIRECTORY ${example_work_dir})
 
 install(TARGETS ${example_name} graphgen)
-install(FILES graph4096.txt graph65536.txt DESTINATION ${CMAKE_INSTALL_PREFIX})
+install(FILES graph4096.txt graph65536.txt TYPE BIN)

--- a/HIP-Doc/Tutorials/Programming-Patterns/histogram_atomics/CMakeLists.txt
+++ b/HIP-Doc/Tutorials/Programming-Patterns/histogram_atomics/CMakeLists.txt
@@ -63,4 +63,4 @@ target_include_directories(${example_name} PRIVATE
 target_link_libraries(${example_name} PRIVATE $<$<LINK_LANGUAGE:CUDA>:CUDA::cuda_driver>)
 
 install(TARGETS ${example_name})
-install(FILES test_colored.jpg DESTINATION ${CMAKE_INSTALL_PREFIX})
+install(FILES test_colored.jpg TYPE BIN)

--- a/HIP-Doc/Tutorials/Programming-Patterns/image_convolution/CMakeLists.txt
+++ b/HIP-Doc/Tutorials/Programming-Patterns/image_convolution/CMakeLists.txt
@@ -63,4 +63,4 @@ target_include_directories(${example_name} PRIVATE
 target_link_libraries(${example_name} PRIVATE $<$<LINK_LANGUAGE:CUDA>:CUDA::cuda_driver>)
 
 install(TARGETS ${example_name})
-install(FILES test.jpg DESTINATION ${CMAKE_INSTALL_PREFIX})
+install(FILES test.jpg TYPE BIN)


### PR DESCRIPTION
## Summary
Cherry-pick of #508 onto `release/therock-7.14`.

- Fix `install(... DESTINATION ${CMAKE_INSTALL_PREFIX})` in the Programming-Patterns examples (bfs, histogram_atomics, image_convolution). CMake treats `${CMAKE_INSTALL_PREFIX}` as an absolute path, causing *permission denied* when the prefix is `/usr/local`. Switched to `TYPE BIN` so graph/image assets land in `bin/` next to their executables.
- Add `cmake --install build --prefix install` to the CMake CI workflows to catch future install regressions, and rename the step to "CMake Configure, Build, and Install".

## Conflict resolution note
This release branch uses the older `amdgpu-install` CI structure rather than the `generate_skip_tests.py`/`SkipExamples.cmake` structure the original #508 was based on. Conflicts in the 7 non-CUDA workflows were resolved by keeping this branch's install structure and applying only the narrow intent of #508 (rename the CMake step + add the `cmake --install` line). No `generate_skip_tests`/`SkipExamples.cmake` was imported.

## Test plan
- [ ] CMake CI workflows configure, build, and install cleanly
- [ ] Programming-Patterns examples install their data files into `bin/` without permission errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)