### PR TITLE
fix(hipFFT): correct multi_gpu example for aligned hipfftXt behavior

### DIFF
--- a/Libraries/hipFFT/multi_gpu/README.md
+++ b/Libraries/hipFFT/multi_gpu/README.md
@@ -1,4 +1,4 @@
-# hipFFT Mutli GPU Example
+# hipFFT Multi GPU Example
 
 ## Description
 
@@ -23,15 +23,15 @@ at least ROCm 6.0.
 
 The application provides the following optional command line arguments:
 
-- `-l` or `--length`. The 3-D FFT size separated by spaces. It default value is `8 8 8`.
-- `-d` or `--devices`. The list of devices to use separated by spaces. It default value is `0 1`.
+- `-l` or `--length`. The 2-D FFT size separated by spaces. Its default value is `8 8`.
+- `-d` or `--devices`. The list of devices to use separated by spaces. Its default value is `0 1`.
 
 ## Key APIs and Concepts
 
 - The `hipfftHandle` needs to be created with `hipfftCreate(...)` before use and destroyed with `hipfftDestroy(...)` after use.
   It can be associated with multiple GPUs.
 - `hipfftXtSetGPUs` instructs a plan to use multiple GPUs.
-- `hipfhipfftMakePlan2dftPlan2d` is used to create a plan for a 2-dimensional FFT.
+- `hipfftMakePlan2d` is used to create a plan for a 2-dimensional FFT.
 - `hipfftXtExecDescriptor` can execute a multi GPU plan.
 - Device memory management:
   - `hipfftXtMalloc` allocates device memory for a plan associated with multiple devices.
@@ -48,7 +48,6 @@ The application provides the following optional command line arguments:
 - `hipfftDestroy`
 - `hipfftHandle`
 - `hipfftMakePlan2d`
-- `hipfftSetStream`
 - `hipfftType`
   - `HIPFFT_Z2Z`
 - `hipfftXtCopyType`
@@ -59,13 +58,9 @@ The application provides the following optional command line arguments:
 - `hipfftXtMemcpy`
 - `hipfftXtSetGPUs`
 - `hipfftXtSubFormat`
-  - `HIPFFT_XT_FORMAT_INPUT`
-  - `HIPFFT_XT_FORMAT_OUTPUT`
+  - `HIPFFT_XT_FORMAT_INPLACE`
 - `hipfftXtExecDescriptor`
 
 ### HIP runtime
 
 - `hipGetDeviceCount`
-- `hipStream_t`
-- `hipStreamCreate`
-- `hipStreamDestroy`

--- a/Libraries/hipFFT/multi_gpu/main.cpp
+++ b/Libraries/hipFFT/multi_gpu/main.cpp
@@ -39,7 +39,7 @@ int main(int argc, char* argv[])
     // 1. Define the various input parameters.
     using data_t = std::complex<double>;
 
-    std::cout << "hipFFT single-node multi-gpu complex-to-complex 3D FFT example\n";
+    std::cout << "hipFFT single-node multi-gpu complex-to-complex 2D FFT example\n";
 
     cli::Parser parser(argc, argv);
     parser.set_optional<std::vector<int>>("l", "length", {8, 8}, "2D FFT size (eg: -l 8 8).");
@@ -80,9 +80,6 @@ int main(int argc, char* argv[])
     HIPFFT_CHECK(hipfftCreate(&plan));
 
     // 4. Set up multi GPU execution.
-    hipStream_t stream{};
-    HIP_CHECK(hipStreamCreate(&stream));
-    HIPFFT_CHECK(hipfftSetStream(plan, stream));
     HIPFFT_CHECK(hipfftXtSetGPUs(plan, devices.size(), devices.data()));
 
     // 5. Make the 2D FFT plan.
@@ -90,36 +87,32 @@ int main(int argc, char* argv[])
     HIPFFT_CHECK(
         hipfftMakePlan2d(plan, length[0], length[1], hipfftType::HIPFFT_Z2Z, work_size.data()));
 
-    // 6. Allocate memory on device.
-    hipLibXtDesc* input_desc;
-    hipLibXtDesc* output_desc;
-    HIPFFT_CHECK(hipfftXtMalloc(plan, &input_desc, hipfftXtSubFormat::HIPFFT_XT_FORMAT_INPUT));
-    HIPFFT_CHECK(hipfftXtMalloc(plan, &output_desc, hipfftXtSubFormat::HIPFFT_XT_FORMAT_OUTPUT));
+    // 6. Allocate memory on device (in-place requires a single descriptor).
+    hipLibXtDesc* desc;
+    HIPFFT_CHECK(hipfftXtMalloc(plan, &desc, hipfftXtSubFormat::HIPFFT_XT_FORMAT_INPLACE));
 
     // 7. Copy data from host to device.
     HIPFFT_CHECK(hipfftXtMemcpy(plan,
-                                input_desc,
+                                desc,
                                 input.data(),
                                 hipfftXtCopyType::HIPFFT_COPY_HOST_TO_DEVICE));
 
-    // 8. Execute multi GPU FFT from plan.
-    HIPFFT_CHECK(hipfftXtExecDescriptor(plan, input_desc, output_desc, HIPFFT_FORWARD));
+    // 8. Execute in-place multi GPU FFT from plan.
+    HIPFFT_CHECK(hipfftXtExecDescriptor(plan, desc, desc, HIPFFT_FORWARD));
 
     // 9. Copy data from device to host.
     std::vector<data_t> output(length[0] * length[1]);
     HIPFFT_CHECK(hipfftXtMemcpy(plan,
                                 output.data(),
-                                output_desc,
+                                desc,
                                 hipfftXtCopyType::HIPFFT_COPY_DEVICE_TO_HOST));
 
     std::cout << "Output:\n";
     print_nd_data(output, length, 16, 3);
 
     // 10. Clean up.
-    HIPFFT_CHECK(hipfftXtFree(input_desc));
-    HIPFFT_CHECK(hipfftXtFree(output_desc));
+    HIPFFT_CHECK(hipfftXtFree(desc));
     HIPFFT_CHECK(hipfftDestroy(plan));
-    HIP_CHECK(hipStreamDestroy(stream));
 
     return 0;
 }


### PR DESCRIPTION
## Motivation

The `multi_gpu` hipFFT example used out-of-place execution with separate `HIPFFT_XT_FORMAT_INPUT`/`HIPFFT_XT_FORMAT_OUTPUT` descriptors, which is unsupported for unbatched multi-dimensional transforms and only worked due to incorrect pre-existing behavior in the rocFFT backend. This PR aligns the example with the cuFFT-compliant in-place semantics enforced by ROCm/rocm-libraries#9318, and fixes several documentation errors.

Ref: ROCm/rocm-libraries#9318

## Technical Details

- Use in-place transform with `HIPFFT_XT_FORMAT_INPLACE` (single descriptor) instead of out-of-place with separate INPUT/OUTPUT descriptors: Unbatched, multi-dimensional, multi-device transforms are in-place only.
- Remove usage of a stream, may be re-introduced after https://github.com/ROCm/rocm-libraries/pull/11331.
- Fix typos in README (title, CLI description, garbled API name) and update demonstrated API list.

## Test Plan

Tested manually on a platform with 8 gfx90a.

## Test Result

Test pass 

## Added/Updated documentation?

- [ ] Yes
- [x] No, does not apply to this PR.

## Included Visual Studio files?

- [ ] Yes
- [x] No, does not apply to this PR.

## Submission Checklist

- [x] New examples contain proper CMake and Make files.
- [x] I have updated relevant CI workflows and the new examples are being built and tested in CI.
- [x] Check and guard against unsupported ASICs if relevant dependent libraries have limited support.
- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
