### PR TITLE
fix(rocProfiler-SDK): buffered-tracing race + thread_trace API sync

### DIFF
--- a/.github/build_tools/skip_manifest.py
+++ b/.github/build_tools/skip_manifest.py
@@ -140,6 +140,19 @@ SKIP_MANIFEST = [
         "channels": ["stable"],
         "reason": "hip_scan.h not present in the pinned 7.14 stable image",
     },
+    # --- Stable-only build skip ------------
+    # The experimental thread-trace shader-data callback was changed to take a
+    # single rocprofiler_thread_trace_shader_data_t struct; the pinned 7.14 stable
+    # image still ships the older multi-arg callback and has no such struct, so the
+    # updated example does not compile there. Nightly TheRock builds carry the new
+    # API and build it, so scope this skip to the stable channel only.
+    {
+        "ctest": None,
+        "path": "Libraries/rocProfiler-SDK/thread_trace",
+        "scope": ["build"],
+        "channels": ["stable"],
+        "reason": "rocprofiler_thread_trace_shader_data_t (new single-struct shader-data callback) absent from the pinned 7.14 stable image",
+    },
     # --- hipThreads: nightly whl build skip (whole tree) ------------------
     # The TheRock nightly whl ships hipthreads headers + libhipthreads.a but an
     # empty include/libhipcxx, so the libhipcxx headers the examples include

--- a/Common/rocprofiler_utils.hpp
+++ b/Common/rocprofiler_utils.hpp
@@ -111,34 +111,40 @@
 /// \brief Checks if the provided rocProfiler status is \p ROCPROFILER_STATUS_SUCCESS and if not,
 /// prints an error message to the standard error output and terminates the program
 /// with an error code.
-#define ROCPROFILER_CHECK(condition)                                                          \
-    {                                                                                         \
-        const rocprofiler_status_t status = condition;                                        \
-        if(status != ROCPROFILER_STATUS_SUCCESS)                                              \
-        {                                                                                     \
-            std::cerr << "rocProfiler error encountered: \""                                  \
-                      << rocprofiler_get_status_string(status) << "\" at " << __FILE__ << ':' \
-                      << __LINE__ << std::endl;                                               \
-            std::exit(error_exit_code);                                                       \
-        }                                                                                     \
+#define ROCPROFILER_CHECK(condition)                                                        \
+    {                                                                                       \
+        const rocprofiler_status_t ROCPROFILER_VARIABLE(CHECKSTATUS, __LINE__) = condition; \
+        if(ROCPROFILER_VARIABLE(CHECKSTATUS, __LINE__) != ROCPROFILER_STATUS_SUCCESS)       \
+        {                                                                                   \
+            std::cerr << "rocProfiler error encountered: \""                                \
+                      << rocprofiler_get_status_string(                                     \
+                             ROCPROFILER_VARIABLE(CHECKSTATUS, __LINE__))                   \
+                      << "\" at " << __FILE__ << ':' << __LINE__ << std::endl;              \
+            std::exit(error_exit_code);                                                     \
+        }                                                                                   \
     }
 
 /// \brief Checks if the provided rocProfiler status is \p ROCPROFILER_STATUS_SUCCESS and if not,
 /// prints an error message with custom message to the standard error output and terminates the
 /// program with an error code.
-#define ROCPROFILER_CALL(condition, msg)                                                   \
-    {                                                                                      \
-        const rocprofiler_status_t status = condition;                                     \
-        if(status != ROCPROFILER_STATUS_SUCCESS)                                           \
-        {                                                                                  \
-            std::cerr << "[" #condition "][" << __FILE__ << ":" << __LINE__ << "] " << msg \
-                      << " failed with error code " << status << ": "                      \
-                      << rocprofiler_get_status_string(status) << std::endl;               \
-            std::stringstream errmsg{};                                                    \
-            errmsg << "[" #condition "][" << __FILE__ << ":" << __LINE__ << "] " << msg    \
-                   << " failure (" << rocprofiler_get_status_string(status) << ")";        \
-            throw std::runtime_error(errmsg.str());                                        \
-        }                                                                                  \
+#define ROCPROFILER_CALL(condition, msg)                                                           \
+    {                                                                                              \
+        const rocprofiler_status_t ROCPROFILER_VARIABLE(CHECKSTATUS, __LINE__) = condition;        \
+        if(ROCPROFILER_VARIABLE(CHECKSTATUS, __LINE__) != ROCPROFILER_STATUS_SUCCESS)              \
+        {                                                                                          \
+            std::cerr << "[" #condition "][" << __FILE__ << ":" << __LINE__ << "] " << msg         \
+                      << " failed with error code " << ROCPROFILER_VARIABLE(CHECKSTATUS, __LINE__) \
+                      << ": "                                                                      \
+                      << rocprofiler_get_status_string(                                            \
+                             ROCPROFILER_VARIABLE(CHECKSTATUS, __LINE__))                          \
+                      << std::endl;                                                                \
+            std::stringstream errmsg{};                                                            \
+            errmsg << "[" #condition "][" << __FILE__ << ":" << __LINE__ << "] " << msg            \
+                   << " failure ("                                                                 \
+                   << rocprofiler_get_status_string(ROCPROFILER_VARIABLE(CHECKSTATUS, __LINE__))   \
+                   << ")";                                                                         \
+            throw std::runtime_error(errmsg.str());                                                \
+        }                                                                                          \
     }
 
 #define ROCPROFILER_VAR_NAME_COMBINE(X, Y) X##Y

--- a/Libraries/rocProfiler-SDK/CMakeLists.txt
+++ b/Libraries/rocProfiler-SDK/CMakeLists.txt
@@ -53,5 +53,4 @@ else()
     message(WARNING "OpenMP offloading target examples are disabled. Skipping rocProfiler-SDK OpenMP target example.")
 endif()
 add_subdirectory(pc_sampling)
-# Disabled until feature is released in future ROCm
-# add_subdirectory(thread_trace)
+add_subdirectory(thread_trace)

--- a/Libraries/rocProfiler-SDK/CMakeLists.txt
+++ b/Libraries/rocProfiler-SDK/CMakeLists.txt
@@ -53,4 +53,4 @@ else()
     message(WARNING "OpenMP offloading target examples are disabled. Skipping rocProfiler-SDK OpenMP target example.")
 endif()
 add_subdirectory(pc_sampling)
-add_subdirectory(thread_trace)
+add_subdirectory(thread_trace) # Available since ROCm 10

--- a/Libraries/rocProfiler-SDK/api_buffered_tracing/client.cpp
+++ b/Libraries/rocProfiler-SDK/api_buffered_tracing/client.cpp
@@ -39,6 +39,7 @@
 #include <rocprofiler-sdk/rocprofiler.h>
 
 #include <cassert>
+#include <mutex>
 
 namespace client
 {
@@ -58,6 +59,14 @@ rocprofiler_context_id_t      client_ctx       = {0};
 rocprofiler_buffer_id_t       client_buffer    = {};
 buffer_name_info              client_name_info = {};
 kernel_symbol_map_t           client_kernels   = {};
+
+// The call_stack_t (tool_data) vector is shared by callbacks that run on different
+// threads concurrently: tool_tracing_callback executes on the rocprofiler buffer
+// callback thread, while thread_precreate/thread_postcreate are invoked from the
+// internal-thread-creation notifier on whichever thread triggers creation of an SDK
+// internal thread (e.g. the async signal handler task group created on the first
+// kernel doorbell). Guard all mutations to avoid a data race / heap corruption.
+std::mutex call_stack_mutex;
 
 void tool_code_object_callback(rocprofiler_callback_tracing_record_t record,
                                rocprofiler_user_data_t*              user_data,
@@ -103,6 +112,8 @@ void tool_tracing_callback(rocprofiler_context_id_t      context,
 {
     assert(user_data != nullptr);
     assert(drop_count == 0 && "drop count should be zero for lossless policy");
+
+    auto _call_stack_lk = std::unique_lock<std::mutex>{call_stack_mutex};
 
     if(num_headers == 0)
         throw std::runtime_error{
@@ -305,6 +316,7 @@ void tool_tracing_callback(rocprofiler_context_id_t      context,
 
 void thread_precreate(rocprofiler_runtime_library_t lib, void* tool_data)
 {
+    auto _call_stack_lk = std::unique_lock<std::mutex>{call_stack_mutex};
     static_cast<call_stack_t*>(tool_data)->emplace_back(
         source_location{__FUNCTION__,
                         __FILE__,
@@ -315,6 +327,7 @@ void thread_precreate(rocprofiler_runtime_library_t lib, void* tool_data)
 
 void thread_postcreate(rocprofiler_runtime_library_t lib, void* tool_data)
 {
+    auto _call_stack_lk = std::unique_lock<std::mutex>{call_stack_mutex};
     static_cast<call_stack_t*>(tool_data)->emplace_back(
         source_location{__FUNCTION__,
                         __FILE__,

--- a/Libraries/rocProfiler-SDK/api_callback_tracing/client.cpp
+++ b/Libraries/rocProfiler-SDK/api_callback_tracing/client.cpp
@@ -283,7 +283,7 @@ void start()
 void stop()
 {
     int status = 0;
-    rocprofiler_is_initialized(&status);
+    ROCPROFILER_CALL(rocprofiler_is_initialized(&status), "failed to retrieve init status");
     if(status != 0)
     {
         ROCPROFILER_CALL(rocprofiler_stop_context(client_ctx), "rocprofiler context stop failed");

--- a/Libraries/rocProfiler-SDK/openmp_target/client.cpp
+++ b/Libraries/rocProfiler-SDK/openmp_target/client.cpp
@@ -568,7 +568,7 @@ void start()
 void stop()
 {
     int status = 0;
-    rocprofiler_is_initialized(&status);
+    ROCPROFILER_CALL(rocprofiler_is_initialized(&status), "failed to retrieve init status");
     if(status != 0)
     {
         ROCPROFILER_CALL(rocprofiler_stop_context(client_ctx), "rocprofiler context stop failed");

--- a/Libraries/rocProfiler-SDK/pc_sampling/client.cpp
+++ b/Libraries/rocProfiler-SDK/pc_sampling/client.cpp
@@ -64,7 +64,7 @@ int tool_init(rocprofiler_client_finalize_t fini_func, void* /*tool_data*/)
     if(client::pcs::gpu_agents.empty())
     {
         *common::get_output_stream()
-            << "No availabe gpu agents supporting PC sampling" << std::endl;
+            << "No available gpu agents supporting PC sampling" << std::endl;
         // Emit the message to explicitly skip the sample.
         std::cerr << "PC sampling unavailable" << std::endl;
         // Exit with no error if none of the GPUs support PC sampling.
@@ -146,7 +146,7 @@ void tool_fini(void* /*tool_data*/)
             }
             else
             {
-                ROCPROFILER_CHECK(ROCPROFILER_STATUS_SUCCESS);
+                ROCPROFILER_CHECK(status);
             }
         }
     }

--- a/Libraries/rocProfiler-SDK/thread_trace/client.cpp
+++ b/Libraries/rocProfiler-SDK/thread_trace/client.cpp
@@ -170,6 +170,10 @@ void tool_codeobj_tracing_callback(rocprofiler_callback_tracing_record_t record,
     {
         return;
     }
+    if(record.phase != ROCPROFILER_CALLBACK_PHASE_LOAD)
+    {
+        return;
+    }
 
     CHECK_NOTNULL(Results::table);
     auto* data = static_cast<rocprofiler_callback_tracing_code_object_load_data_t*>(record.payload);
@@ -200,10 +204,7 @@ void tool_codeobj_tracing_callback(rocprofiler_callback_tracing_record_t record,
                                data->load_size);
 }
 
-void shader_data_callback(rocprofiler_agent_id_t /* agent */,
-                          int64_t /* se_id */,
-                          void*  se_data,
-                          size_t data_size,
+void shader_data_callback(rocprofiler_thread_trace_shader_data_t shader_data,
                           rocprofiler_user_data_t /* userdata */)
 {
     CHECK_NOTNULL(Results::latencies);
@@ -250,7 +251,9 @@ void shader_data_callback(rocprofiler_agent_id_t /* agent */,
         }
     };
 
-    DECODER_CALL(rocprofiler_trace_decode(decoder, parse, se_data, data_size, nullptr));
+    auto* data = static_cast<char*>(shader_data.data) + shader_data.read_offset;
+    auto  size = shader_data.data_size - shader_data.read_offset;
+    DECODER_CALL(rocprofiler_trace_decode(decoder, parse, data, size, nullptr));
 }
 
 } // namespace Decoder
@@ -278,9 +281,10 @@ rocprofiler_status_t query_available_agents(rocprofiler_agent_version_t /* versi
         }
 
         auto parameters = std::vector<rocprofiler_thread_trace_parameter_t>{};
-        parameters.push_back({ROCPROFILER_THREAD_TRACE_PARAMETER_TARGET_CU, TARGET_CU});
-        parameters.push_back({ROCPROFILER_THREAD_TRACE_PARAMETER_BUFFER_SIZE, BUFFER_SIZE});
-        parameters.push_back({ROCPROFILER_THREAD_TRACE_PARAMETER_SHADER_ENGINE_MASK, SHADER_MASK});
+        parameters.push_back({ROCPROFILER_THREAD_TRACE_PARAMETER_TARGET_CU, {TARGET_CU}});
+        parameters.push_back({ROCPROFILER_THREAD_TRACE_PARAMETER_BUFFER_SIZE, {BUFFER_SIZE}});
+        parameters.push_back(
+            {ROCPROFILER_THREAD_TRACE_PARAMETER_SHADER_ENGINE_MASK, {SHADER_MASK}});
 
         ROCPROFILER_CALL(
             rocprofiler_configure_device_thread_trace_service(agent_ctx,


### PR DESCRIPTION
## Summary

Two related fixes bringing the rocProfiler-SDK examples back in line with the upstream samples (ROCm/rocm-systems, `projects/rocprofiler-sdk/samples`), which had diverged.

### 1. Fix buffered-tracing data race + sync examples with upstream
- **api_buffered_tracing**: guard the shared `call_stack_t` (`tool_data`) vector with a mutex. It is written concurrently from the async buffer-flush thread and the `thread_precreate`/`thread_postcreate` callbacks with no synchronization, so overlapping reallocations corrupt the heap and abort with "double free or corruption" on the first kernel launch. This was the root cause of the timing-dependent CI aborts of `rocprofiler-sdk_api_buffered_tracing`. Verified on a repro host: original crashed 5/5, fixed passed 10/10.
- **Common/rocprofiler_utils.hpp**: make `ROCPROFILER_CHECK`/`ROCPROFILER_CALL` use a `__LINE__`-uniqued internal variable (`ROCPROFILER_VARIABLE(CHECKSTATUS, __LINE__)`), matching upstream's `defines.hpp` and the existing `ROCPROFILER_WARN`. The previous plain `status` collided with a caller variable named `status`.
- **pc_sampling**: check the real status from `rocprofiler_destroy_buffer` instead of the constant `ROCPROFILER_STATUS_SUCCESS` (which made the check a no-op); fix "availabe" typo.
- **api_callback_tracing, openmp_target**: wrap `rocprofiler_is_initialized()` in `ROCPROFILER_CALL` so a failed query is not silently ignored (relies on the macro-hygiene fix above).

### 2. Update thread_trace to current SDK thread-trace API
- The experimental thread-trace shader-data callback contract changed between ROCm releases: `rocprofiler_thread_trace_shader_data_callback_t` now takes a single `rocprofiler_thread_trace_shader_data_t` struct. This struct-based form is available since ROCm 10; the pinned 7.14 stable image still ships the older multi-argument callback (`agent, shader_engine_id, data, data_size, flags, userdata`) and has no such struct, so the updated example does not compile there.
- `shader_data_callback`: take the struct; decode from `shader_data.data + read_offset` for `shader_data.data_size - read_offset` bytes.
- `tool_codeobj_tracing_callback`: only handle `ROCPROFILER_CALLBACK_PHASE_LOAD`.
- Brace-init the thread-trace parameter union values.
- **Enable `thread_trace` in the suite CMake** (`add_subdirectory`). It was previously commented out ("Disabled until feature is released"), which is why the API break escaped CI. It now builds on the nightly TheRock channel (which carries the new API).
- **Skip `thread_trace` on the pinned 7.14 stable image** via a stable-channel build entry in the skip manifest (`.github/build_tools/skip_manifest.py`), since that image predates the new struct API. Nightly builds are unaffected and still compile it.

## Test plan
- [x] Full-suite cmake build with `-DROCM_EXAMPLES_ENABLE_OPENMP=ON` — configure + build exit 0, all targets including `rocprofiler-sdk_thread_trace` produced.
- [x] Skip manifest: `--channel stable` lists `Libraries/rocProfiler-SDK/thread_trace` in `skip_build.txt` and the CMake override drops it (`SkipExamples: skipping ...`); `--channel nightly` does not skip it.
- [x] api_buffered_tracing race repro: 5/5 crash before, 10/10 pass after.
- [ ] CI green: nightly builds thread_trace, 7.14 stable skips it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)