### PR TITLE
[CI] update Quartz consumer for status.json schema 2.1 and nightly/ path

### DIFF
--- a/.github/quartz/consume_status.py
+++ b/.github/quartz/consume_status.py
@@ -36,6 +36,7 @@ from read_status_json import (
     DEFAULT_SOURCE,
     Status,
     StatusDocument,
+    UnsupportedSchemaError,
     load_status,
 )
 
@@ -44,11 +45,6 @@ from read_status_json import (
 # pipeline across platforms and is routinely red even when ROCm itself is fine).
 PLATFORM = "linux"
 PIPELINE = "rocm"
-
-# The status.json schema major this consumer understands. A bump to a new major
-# can move or rename the fields the accessors read, so an unsupported major is a
-# hard failure, not a soft skip (mirrors ROCm/Quartz example_consume_status.py).
-SUPPORTED_SCHEMA_MAJOR = "2."
 
 
 class Resolution(NamedTuple):
@@ -103,19 +99,20 @@ def resolve(source: str | None, arch: str) -> Resolution:
     """
     try:
         status = load_status(source)
+    except UnsupportedSchemaError as exc:
+        # An unsupported schema major is permanent, unlike a transient fetch
+        # hiccup: retrying will not help, and a new major can move or rename the
+        # fields the accessors read, so continuing risks silently misreading the
+        # document. load_status raises this from its own version guard; catch it
+        # before the transient clause below (UnsupportedSchemaError is a
+        # ValueError subclass) and fail loudly so the consumer gets updated,
+        # rather than reporting a false "nothing ready" that hides the break on
+        # every future poll. Newer minors within the supported major are accepted
+        # by load_status and need no handling here.
+        sys.exit(f"{exc} Update the consumer.")
     except (OSError, ValueError) as exc:
         print(f"Quartz status unavailable: {exc}", file=sys.stderr)
         return Resolution(False, None, "unavailable")
-    # An unsupported schema major is permanent, unlike a transient fetch hiccup:
-    # retrying will not help, and a new major can move or rename the fields the
-    # accessors read, so continuing risks silently misreading the document. Fail
-    # loudly so the consumer gets updated, rather than reporting a false "nothing
-    # ready" that hides the break on every future poll.
-    if not status.schema_version.startswith(SUPPORTED_SCHEMA_MAJOR):
-        sys.exit(
-            f"schema_version {status.schema_version} unsupported "
-            f"(this consumer handles {SUPPORTED_SCHEMA_MAJOR}x); update the consumer."
-        )
     if arch_is_good(status, arch):
         return Resolution(True, status, "latest")
     return Resolution(False, status, "not-ready")

--- a/.github/quartz/tests/test_consume_status.py
+++ b/.github/quartz/tests/test_consume_status.py
@@ -25,10 +25,10 @@ from pathlib import Path
 sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
 
 import consume_status  # noqa: E402
-from read_status_json import StatusDocument  # noqa: E402
+from read_status_json import StatusDocument, UnsupportedSchemaError  # noqa: E402
 
 
-def make_status(schema="2.0", build_status="success", arches=("gfx110X-all",)):
+def make_status(schema="2.1", build_status="success", arches=("gfx110X-all",)):
     """Build a minimal v2-shaped status document for the Linux ROCm gate."""
     return StatusDocument(
         {
@@ -65,7 +65,7 @@ class ArchIsGoodTest(unittest.TestCase):
         )
 
     def test_missing_linux_platform(self):
-        status = StatusDocument({"schema_version": "2.0", "summary": {}})
+        status = StatusDocument({"schema_version": "2.1", "summary": {}})
         self.assertFalse(consume_status.arch_is_good(status, ""))
 
 
@@ -99,7 +99,13 @@ class ResolveTest(unittest.TestCase):
         self.assertEqual(source, "unavailable")
 
     def test_resolve_bad_schema_major_exits(self):
-        self._patch_load(lambda *a, **k: make_status(schema="3.0"))
+        # load_status guards the schema major itself and raises
+        # UnsupportedSchemaError; resolve() must exit non-zero, not treat it as a
+        # transient "unavailable" (it is a ValueError subclass).
+        def boom(*a, **k):
+            raise UnsupportedSchemaError("schema_version 3.0 unsupported")
+
+        self._patch_load(boom)
         with self.assertRaises(SystemExit):
             consume_status.resolve(None, "")
 

--- a/.github/workflows/quartz_test.yml
+++ b/.github/workflows/quartz_test.yml
@@ -64,14 +64,13 @@ jobs:
         uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
 
       # Quartz's reusable status.json reader, sparse-checked-out (single file) at
-      # a pinned commit rather than vendored. Pinned to the ROCm/Quartz#91 merge,
-      # which shipped the schema-v2 reader that follows the latest.json symlink;
+      # a pinned commit (main branch) rather than vendored.
       # bump this SHA to pick up reader fixes or a schema-major update.
       - name: Sparse-checkout Quartz reader
         uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
         with:
           repository: ROCm/Quartz
-          ref: 910cc21e061790356f2697eaeb25e0db596f3dc3
+          ref: 9f81d2cb6a90b1ad08cc092b9a76847bc34fb4f9 # 20260908
           sparse-checkout: scripts/consumer/read_status_json.py
           sparse-checkout-cone-mode: false
           path: .quartz-upstream


### PR DESCRIPTION
## Summary

We update the Quartz consumer scripts added in #512 to follow two upstream
Quartz changes now merged to `main`: the status.json schema bump to **2.1**
(ROCm/Quartz#98) and the move of the published nightly status from
`release-nightly/` to `nightly/` (ROCm/Quartz#93). Both land through a single
pinned-SHA bump plus one behavioral fix in the consumer.

## What changed

- **Pin bump** (`quartz_test.yml`): the sparse-checkout ref moves from the
  ROCm/Quartz#91 merge to `9f81d2cb6a90b1ad08cc092b9a76847bc34fb4f9`, the `main`
  merge commit that brings in 
see also ROCm/Quartz#98 and ROCm/Quartz#93. Pinning to `main` (not the develop
  tip) keeps the reader on an immutable, released commit; the reader there is
  byte-identical to develop's. The `nightly/` path move needs no code edit on
  our side: it lives in the reader's `DEFAULT_SOURCE`, which the pin picks up.

- **Schema-major guard** (`consume_status.py`): with ROCm/Quartz#98, `load_status` now
  raises `UnsupportedSchemaError` (a `ValueError` subclass) on a schema-major
  mismatch, rather than us checking `schema_version` after the fact. Left
  unchanged, our `except (OSError, ValueError)` would swallow it and mislabel a
  permanent break as a transient "unavailable", retried on every poll. We now
  catch `UnsupportedSchemaError` *before* the transient clause and exit
  non-zero, mirroring Quartz's own updated example consumer. The redundant
  `SUPPORTED_SCHEMA_MAJOR` constant and manual check are removed; the reader
  owns that guard and accepts newer minors within major 2.

- **Tests** (`test_consume_status.py`): the schema-major-exit test now drives
  the reader's raise (`load_status` raising `UnsupportedSchemaError`) instead of
  the removed post-load check; fixtures move to schema 2.1.

## Test plan

- [x] `consume_status.py` unit tests pass against the schema-2.1 reader
      (`PYTHONPATH=<quartz>/scripts/consumer python3 -m unittest discover -s .github/quartz/tests`) — 10/10 green
- [x] Consumer resolves the reader's new `DEFAULT_SOURCE` (`nightly/latest.json`)
- [x] Workflow YAML parses

## Note

`nightly/latest.json` is not yet live on `main` (today's in-flight nightly still
writes to `release-nightly/` per ROCm/Quartz#93); the gate harmlessly reports
`resolved=false` and skips until the next nightly publishes under `nightly/`.
