### PR TITLE
ci(quartz): classify infra vs build/test failures; retry until infra is healthy

### DIFF
--- a/.github/workflows/build-rocm-examples-reusable.yml
+++ b/.github/workflows/build-rocm-examples-reusable.yml
@@ -58,10 +58,12 @@ jobs:
         gpu_config: ${{ fromJson(inputs.gpu_configs) }}
     steps:
       - name: Checkout repository
+        id: checkout
         uses: actions/checkout@v4
 
       - name: Install ROCm (whl-multi-arch)
         if: ${{ matrix.install_method == 'whl-multi-arch' }}
+        id: install-whl
         run: |
           echo "## Target: ${{ matrix.gpu_config.gpu_target }} on ${{ fromJson(inputs.distro_map)[inputs.distro].label }}" >> $GITHUB_STEP_SUMMARY
           pip install --no-cache-dir --upgrade pip
@@ -127,6 +129,7 @@ jobs:
 
       - name: Setup environment variables (tarball-multi-arch)
         if: ${{ matrix.install_method == 'tarball-multi-arch' }}
+        id: setup-env-tarball
         run: |
           ROCM_PATH=/therock-tarball/install
           echo "ROCM_PATH=${ROCM_PATH}" >> $GITHUB_ENV
@@ -154,7 +157,29 @@ jobs:
           echo "ENABLE_CK=OFF" >> $GITHUB_ENV
           echo "HIPCC_COMPILE_FLAGS_APPEND=--offload-arch=${{ matrix.gpu_config.gpu_target }}" >> $GITHUB_ENV
 
+      - name: Prep status
+        id: prep
+        if: always()
+        run: |
+          # "Prep" = everything needed before our builds: checkout, ROCm install, env
+          # setup. A failure here is transient infra (network/index/runner), not a code
+          # bug -- classified infra so the version is retried, not recorded broken.
+          ok=true
+          for oc in "${{ steps.checkout.outcome }}" \
+                    "${{ steps.install-whl.outcome }}" \
+                    "${{ steps.whl-multiarch-version.outcome }}" \
+                    "${{ steps.install-tarball-multi-arch.outcome }}" \
+                    "${{ steps.setup-env-tarball.outcome }}" \
+                    "${{ steps.preinstalled.outcome }}"; do
+            [ "$oc" = "failure" ] && ok=false
+          done
+          echo "ok=$ok" >> "$GITHUB_OUTPUT"
+
+      # The collect job in quartz_test.yml classifies each cell from these build/test
+      # step ids/outcomes; keep the ids stable when renaming steps.
       - name: Generate skip lists
+        if: ${{ !cancelled() && steps.prep.outputs.ok == 'true' }}
+        id: skip-lists
         run: |
           # The preinstalled distro is the pinned rocm:7.14 image, i.e. the "stable"
           # channel; every other install method pulls a TheRock "nightly" build.
@@ -170,17 +195,21 @@ jobs:
             --install-method "${{ matrix.install_method }}"
 
       - name: Makefile build
+        if: ${{ !cancelled() && steps.prep.outputs.ok == 'true' && steps.skip-lists.outcome == 'success' }}
+        id: mk-build
         run: |
           ./Scripts/configure.sh --rocm-path="${ROCM_PATH}"
           make -j HIP_ARCHITECTURES="${{ matrix.gpu_config.gpu_target }}" SKIP_FROM_BUILD="$SKIP_FROM_BUILD"
 
       - name: CMake configure
-        if: ${{ !cancelled() }}
+        if: ${{ !cancelled() && steps.prep.outputs.ok == 'true' && steps.skip-lists.outcome == 'success' }}
+        id: cmake-configure
         run: |
           cmake -S . -B build -DCMAKE_HIP_ARCHITECTURES="${{ matrix.gpu_config.gpu_target }}" -DCMAKE_BUILD_RPATH="${ROCM_PATH}/lib" -DROCM_EXAMPLES_ENABLE_OPENMP="${ENABLE_OPENMP}" -DROCM_EXAMPLES_ENABLE_CK="${ENABLE_CK}" -DCMAKE_PROJECT_INCLUDE_BEFORE="${GITHUB_WORKSPACE}/Common/SkipExamples.cmake" 2> >(tee cmake_error.log >&2)
 
       - name: CMake configure error summary
         if: ${{ !cancelled() }}
+        continue-on-error: true
         run: |
           if [ ! -f cmake_error.log ]; then
             exit 0
@@ -211,17 +240,20 @@ jobs:
           fi
 
       - name: CMake build
-        if: ${{ !cancelled() }}
+        if: ${{ !cancelled() && steps.cmake-configure.outcome == 'success' }}
+        id: cmake-build
         run: |
           cmake --build build -j
 
       - name: CMake install
-        if: ${{ !cancelled() }}
+        if: ${{ !cancelled() && steps.cmake-build.outcome == 'success' }}
+        id: cmake-install
         run: |
           cmake --install build --prefix install
 
       - name: Collect Makefile build artifacts
         if: ${{ !cancelled() }}
+        continue-on-error: true
         run: |
           mkdir -p /tmp/makefile_build
           find . -name Makefile -not -path './build/*' | while IFS= read -r makefile; do
@@ -235,6 +267,7 @@ jobs:
 
       - name: Upload CMake build artifacts
         if: ${{ !cancelled() }}
+        continue-on-error: true
         uses: actions/upload-artifact@v4
         with:
           name: rocm-examples-build-${{ inputs.distro }}-${{ matrix.gpu_config.gpu_target }}-${{ steps.whl-multiarch-version.outputs.rocm_version || steps.install-tarball-multi-arch.outputs.rocm_version || steps.preinstalled.outputs.rocm_version }}-${{ matrix.install_method }}
@@ -242,13 +275,15 @@ jobs:
 
       - name: Upload Makefile build artifacts
         if: ${{ !cancelled() }}
+        continue-on-error: true
         uses: actions/upload-artifact@v4
         with:
           name: makefile-build-${{ inputs.distro }}-${{ matrix.gpu_config.gpu_target }}-${{ steps.whl-multiarch-version.outputs.rocm_version || steps.install-tarball-multi-arch.outputs.rocm_version || steps.preinstalled.outputs.rocm_version }}-${{ matrix.install_method }}
           path: /tmp/makefile_build/
 
       - name: Run tests
-        if: ${{ !cancelled() }}
+        if: ${{ !cancelled() && steps.cmake-install.outcome == 'success' }}
+        id: ctest
         run: |
           # skip_tests.txt was produced by the "Generate skip lists" step,
           # which also reports the full skip manifest to the step summary.
@@ -257,6 +292,7 @@ jobs:
 
       - name: Test summary
         if: ${{ !cancelled() }}
+        continue-on-error: true
         run: |
           LAST_TEST_LOG="build/Testing/Temporary/LastTest.log"
           if [ ! -f ctest_output.log ] || [ ! -f "${LAST_TEST_LOG}" ]; then
@@ -298,22 +334,54 @@ jobs:
 
       - name: Upload test logs
         if: ${{ !cancelled() }}
+        continue-on-error: true
         uses: actions/upload-artifact@v4
         with:
           name: ctest-logs-${{ inputs.distro }}-${{ matrix.gpu_config.gpu_target }}-${{ steps.whl-multiarch-version.outputs.rocm_version || steps.install-tarball-multi-arch.outputs.rocm_version || steps.preinstalled.outputs.rocm_version }}-${{ matrix.install_method }}
           path: build/Testing/Temporary/
 
       - name: Makefile test
-        if: ${{ !cancelled() }}
+        if: ${{ !cancelled() && steps.mk-build.outcome == 'success' }}
+        id: mk-test
         run: |
           make test HIP_ARCHITECTURES="${{ matrix.gpu_config.gpu_target }}" SKIP_FROM_TEST="$SKIP_FROM_TEST" 2>&1 | tee makefile_test_output.log
 
       - name: Upload Makefile test logs
         if: ${{ !cancelled() }}
+        continue-on-error: true
         uses: actions/upload-artifact@v4
         with:
           name: makefile-test-logs-${{ inputs.distro }}-${{ matrix.gpu_config.gpu_target }}-${{ steps.whl-multiarch-version.outputs.rocm_version || steps.install-tarball-multi-arch.outputs.rocm_version || steps.preinstalled.outputs.rocm_version }}-${{ matrix.install_method }}
           path: makefile_test_output.log
+
+      - name: Classify outcome
+        if: always()
+        run: |
+          # prep failure -> infra (retry). Otherwise any of our build/test steps failing
+          # -> a genuine bug (record as tested so it is not retried). The collect job in
+          # quartz_test.yml takes the worst category across all cells.
+          if [ "${{ steps.prep.outputs.ok }}" != "true" ]; then
+            c=infra
+          elif [ "${{ steps.skip-lists.outcome }}" = "failure" ] \
+            || [ "${{ steps.mk-build.outcome }}" = "failure" ] \
+            || [ "${{ steps.cmake-configure.outcome }}" = "failure" ] \
+            || [ "${{ steps.cmake-build.outcome }}" = "failure" ] \
+            || [ "${{ steps.cmake-install.outcome }}" = "failure" ] \
+            || [ "${{ steps.ctest.outcome }}" = "failure" ] \
+            || [ "${{ steps.mk-test.outcome }}" = "failure" ]; then
+            c=bug
+          else
+            c=success
+          fi
+          echo "$c" > cell-category.txt
+          echo "Cell category: $c" >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Upload cell category
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: category-${{ inputs.distro }}-${{ matrix.gpu_config.gpu_target }}-${{ matrix.install_method }}
+          path: cell-category.txt
 
       - name: Clean the workspace
         if: always()

--- a/.github/workflows/build-rocm-examples-reusable.yml
+++ b/.github/workflows/build-rocm-examples-reusable.yml
@@ -59,7 +59,7 @@ jobs:
     steps:
       - name: Checkout repository
         id: checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
 
       - name: Install ROCm (whl-multi-arch)
         if: ${{ matrix.install_method == 'whl-multi-arch' }}
@@ -83,6 +83,7 @@ jobs:
             --index-url "$INDEX_URL" \
             "$PKG"
           rocm-sdk init
+          echo "install_url=$INDEX_URL" >> "$GITHUB_OUTPUT"
 
       - name: Wheel sanity check
         if: ${{ matrix.install_method == 'whl-multi-arch' }}
@@ -124,6 +125,7 @@ jobs:
 
           ROCM_VERSION=$(echo "${LATEST_TARBALL}" | grep -oE "[0-9]+\.[0-9]+\.\w+")
           echo "rocm_version=${ROCM_VERSION}" >> $GITHUB_OUTPUT
+          echo "install_url=${TARBALL_BASE}${LATEST_TARBALL}" >> $GITHUB_OUTPUT
           echo "## ROCm Version: ${ROCM_VERSION}" >> $GITHUB_STEP_SUMMARY
           echo "## Tarball link: ${TARBALL_BASE}${LATEST_TARBALL}" >> $GITHUB_STEP_SUMMARY
 
@@ -167,6 +169,7 @@ jobs:
           ok=true
           for oc in "${{ steps.checkout.outcome }}" \
                     "${{ steps.install-whl.outcome }}" \
+                    "${{ steps.sanity-check.outcome }}" \
                     "${{ steps.whl-multiarch-version.outcome }}" \
                     "${{ steps.install-tarball-multi-arch.outcome }}" \
                     "${{ steps.setup-env-tarball.outcome }}" \
@@ -176,7 +179,7 @@ jobs:
           echo "ok=$ok" >> "$GITHUB_OUTPUT"
 
       # The Classify outcome step below reads these build/test step ids/outcomes
-      # to categorize the cell (infra/bug/success); keep the ids stable when
+      # to categorize the matrix job (infra/bug/success); keep the ids stable when
       # renaming steps.
       - name: Generate skip lists
         if: ${{ !cancelled() && steps.environment-status.outputs.ok == 'true' }}
@@ -196,14 +199,14 @@ jobs:
             --install-method "${{ matrix.install_method }}"
 
       - name: Makefile build
-        if: ${{ !cancelled() && steps.environment-status.outputs.ok == 'true' && steps.skip-lists.outcome == 'success' }}
+        if: ${{ !cancelled() && steps.skip-lists.outcome == 'success' }}
         id: make-build
         run: |
           ./Scripts/configure.sh --rocm-path="${ROCM_PATH}"
           make -j HIP_ARCHITECTURES="${{ matrix.gpu_config.gpu_target }}" SKIP_FROM_BUILD="$SKIP_FROM_BUILD"
 
       - name: CMake configure
-        if: ${{ !cancelled() && steps.environment-status.outputs.ok == 'true' && steps.skip-lists.outcome == 'success' }}
+        if: ${{ !cancelled() && steps.skip-lists.outcome == 'success' }}
         id: cmake-configure
         run: |
           cmake -S . -B build -DCMAKE_HIP_ARCHITECTURES="${{ matrix.gpu_config.gpu_target }}" -DCMAKE_BUILD_RPATH="${ROCM_PATH}/lib" -DROCM_EXAMPLES_ENABLE_OPENMP="${ENABLE_OPENMP}" -DROCM_EXAMPLES_ENABLE_CK="${ENABLE_CK}" -DCMAKE_PROJECT_INCLUDE_BEFORE="${GITHUB_WORKSPACE}/Common/SkipExamples.cmake" 2> >(tee cmake_error.log >&2)
@@ -268,16 +271,18 @@ jobs:
 
       - name: Upload CMake build artifacts
         if: ${{ !cancelled() }}
+        id: upload-cmake-build
         continue-on-error: true
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
           name: rocm-examples-build-${{ inputs.distro }}-${{ matrix.gpu_config.gpu_target }}-${{ steps.whl-multiarch-version.outputs.rocm_version || steps.install-tarball-multi-arch.outputs.rocm_version || steps.preinstalled.outputs.rocm_version }}-${{ matrix.install_method }}
           path: build/
 
       - name: Upload Makefile build artifacts
         if: ${{ !cancelled() }}
+        id: upload-make-build
         continue-on-error: true
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
           name: makefile-build-${{ inputs.distro }}-${{ matrix.gpu_config.gpu_target }}-${{ steps.whl-multiarch-version.outputs.rocm_version || steps.install-tarball-multi-arch.outputs.rocm_version || steps.preinstalled.outputs.rocm_version }}-${{ matrix.install_method }}
           path: /tmp/makefile_build/
@@ -335,8 +340,9 @@ jobs:
 
       - name: Upload test logs
         if: ${{ !cancelled() }}
+        id: upload-ctest-logs
         continue-on-error: true
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
           name: ctest-logs-${{ inputs.distro }}-${{ matrix.gpu_config.gpu_target }}-${{ steps.whl-multiarch-version.outputs.rocm_version || steps.install-tarball-multi-arch.outputs.rocm_version || steps.preinstalled.outputs.rocm_version }}-${{ matrix.install_method }}
           path: build/Testing/Temporary/
@@ -349,8 +355,9 @@ jobs:
 
       - name: Upload Makefile test logs
         if: ${{ !cancelled() }}
+        id: upload-make-test-logs
         continue-on-error: true
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
           name: makefile-test-logs-${{ inputs.distro }}-${{ matrix.gpu_config.gpu_target }}-${{ steps.whl-multiarch-version.outputs.rocm_version || steps.install-tarball-multi-arch.outputs.rocm_version || steps.preinstalled.outputs.rocm_version }}-${{ matrix.install_method }}
           path: makefile_test_output.log
@@ -358,10 +365,15 @@ jobs:
       - name: Classify outcome
         if: always()
         run: |
-          # Env failure -> infra (retry). Otherwise any of our build/test steps failing
+          # Env failure, or a failed artifact upload, -> infra (retry): both are
+          # transient, not a code bug. Otherwise any of our build/test steps failing
           # -> a genuine bug (record as tested so it is not retried). The collect job in
-          # quartz_test.yml takes the worst category across all cells.
-          if [ "${{ steps.environment-status.outputs.ok }}" != "true" ]; then
+          # quartz_test.yml takes the worst category across all matrix jobs.
+          if [ "${{ steps.environment-status.outputs.ok }}" != "true" ] \
+            || [ "${{ steps.upload-cmake-build.outcome }}" = "failure" ] \
+            || [ "${{ steps.upload-make-build.outcome }}" = "failure" ] \
+            || [ "${{ steps.upload-ctest-logs.outcome }}" = "failure" ] \
+            || [ "${{ steps.upload-make-test-logs.outcome }}" = "failure" ]; then
             c=infra
           elif [ "${{ steps.skip-lists.outcome }}" = "failure" ] \
             || [ "${{ steps.cmake-configure.outcome }}" = "failure" ] \
@@ -374,12 +386,20 @@ jobs:
           else
             c=success
           fi
-          echo "$c" > job-status.txt
+          # First line is the bare category (collect aggregates it with `grep -qx`);
+          # the metadata lines below it are inert to that match.
+          rocm_version="${{ steps.whl-multiarch-version.outputs.rocm_version || steps.install-tarball-multi-arch.outputs.rocm_version || steps.preinstalled.outputs.rocm_version }}"
+          install_url="${{ steps.install-whl.outputs.install_url || steps.install-tarball-multi-arch.outputs.install_url }}"
+          {
+            echo "$c"
+            echo "rocm_version=$rocm_version"
+            echo "install_url=$install_url"
+          } > job-status.txt
           echo "Job status: $c" >> "$GITHUB_STEP_SUMMARY"
 
       - name: Upload job status
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
           name: status-${{ inputs.distro }}-${{ matrix.gpu_config.gpu_target }}-${{ matrix.install_method }}
           path: job-status.txt

--- a/.github/workflows/build-rocm-examples-reusable.yml
+++ b/.github/workflows/build-rocm-examples-reusable.yml
@@ -157,11 +157,11 @@ jobs:
           echo "ENABLE_CK=OFF" >> $GITHUB_ENV
           echo "HIPCC_COMPILE_FLAGS_APPEND=--offload-arch=${{ matrix.gpu_config.gpu_target }}" >> $GITHUB_ENV
 
-      - name: Prep status
-        id: prep
+      - name: Environment status check
+        id: environment-status
         if: always()
         run: |
-          # "Prep" = everything needed before our builds: checkout, ROCm install, env
+          # Everything needed before our builds: checkout, ROCm install, env
           # setup. A failure here is transient infra (network/index/runner), not a code
           # bug -- classified infra so the version is retried, not recorded broken.
           ok=true
@@ -175,10 +175,11 @@ jobs:
           done
           echo "ok=$ok" >> "$GITHUB_OUTPUT"
 
-      # The collect job in quartz_test.yml classifies each cell from these build/test
-      # step ids/outcomes; keep the ids stable when renaming steps.
+      # The Classify outcome step below reads these build/test step ids/outcomes
+      # to categorize the cell (infra/bug/success); keep the ids stable when
+      # renaming steps.
       - name: Generate skip lists
-        if: ${{ !cancelled() && steps.prep.outputs.ok == 'true' }}
+        if: ${{ !cancelled() && steps.environment-status.outputs.ok == 'true' }}
         id: skip-lists
         run: |
           # The preinstalled distro is the pinned rocm:7.14 image, i.e. the "stable"
@@ -195,14 +196,14 @@ jobs:
             --install-method "${{ matrix.install_method }}"
 
       - name: Makefile build
-        if: ${{ !cancelled() && steps.prep.outputs.ok == 'true' && steps.skip-lists.outcome == 'success' }}
-        id: mk-build
+        if: ${{ !cancelled() && steps.environment-status.outputs.ok == 'true' && steps.skip-lists.outcome == 'success' }}
+        id: make-build
         run: |
           ./Scripts/configure.sh --rocm-path="${ROCM_PATH}"
           make -j HIP_ARCHITECTURES="${{ matrix.gpu_config.gpu_target }}" SKIP_FROM_BUILD="$SKIP_FROM_BUILD"
 
       - name: CMake configure
-        if: ${{ !cancelled() && steps.prep.outputs.ok == 'true' && steps.skip-lists.outcome == 'success' }}
+        if: ${{ !cancelled() && steps.environment-status.outputs.ok == 'true' && steps.skip-lists.outcome == 'success' }}
         id: cmake-configure
         run: |
           cmake -S . -B build -DCMAKE_HIP_ARCHITECTURES="${{ matrix.gpu_config.gpu_target }}" -DCMAKE_BUILD_RPATH="${ROCM_PATH}/lib" -DROCM_EXAMPLES_ENABLE_OPENMP="${ENABLE_OPENMP}" -DROCM_EXAMPLES_ENABLE_CK="${ENABLE_CK}" -DCMAKE_PROJECT_INCLUDE_BEFORE="${GITHUB_WORKSPACE}/Common/SkipExamples.cmake" 2> >(tee cmake_error.log >&2)
@@ -282,7 +283,7 @@ jobs:
           path: /tmp/makefile_build/
 
       - name: Run tests
-        if: ${{ !cancelled() && steps.cmake-install.outcome == 'success' }}
+        if: ${{ !cancelled() && steps.cmake-build.outcome == 'success' }}
         id: ctest
         run: |
           # skip_tests.txt was produced by the "Generate skip lists" step,
@@ -341,8 +342,8 @@ jobs:
           path: build/Testing/Temporary/
 
       - name: Makefile test
-        if: ${{ !cancelled() && steps.mk-build.outcome == 'success' }}
-        id: mk-test
+        if: ${{ !cancelled() && steps.make-build.outcome == 'success' }}
+        id: make-test
         run: |
           make test HIP_ARCHITECTURES="${{ matrix.gpu_config.gpu_target }}" SKIP_FROM_TEST="$SKIP_FROM_TEST" 2>&1 | tee makefile_test_output.log
 
@@ -357,31 +358,31 @@ jobs:
       - name: Classify outcome
         if: always()
         run: |
-          # prep failure -> infra (retry). Otherwise any of our build/test steps failing
+          # Env failure -> infra (retry). Otherwise any of our build/test steps failing
           # -> a genuine bug (record as tested so it is not retried). The collect job in
           # quartz_test.yml takes the worst category across all cells.
-          if [ "${{ steps.prep.outputs.ok }}" != "true" ]; then
+          if [ "${{ steps.environment-status.outputs.ok }}" != "true" ]; then
             c=infra
           elif [ "${{ steps.skip-lists.outcome }}" = "failure" ] \
-            || [ "${{ steps.mk-build.outcome }}" = "failure" ] \
             || [ "${{ steps.cmake-configure.outcome }}" = "failure" ] \
             || [ "${{ steps.cmake-build.outcome }}" = "failure" ] \
             || [ "${{ steps.cmake-install.outcome }}" = "failure" ] \
             || [ "${{ steps.ctest.outcome }}" = "failure" ] \
-            || [ "${{ steps.mk-test.outcome }}" = "failure" ]; then
+            || [ "${{ steps.make-build.outcome }}" = "failure" ] \
+            || [ "${{ steps.make-test.outcome }}" = "failure" ]; then
             c=bug
           else
             c=success
           fi
-          echo "$c" > cell-category.txt
-          echo "Cell category: $c" >> "$GITHUB_STEP_SUMMARY"
+          echo "$c" > job-status.txt
+          echo "Job status: $c" >> "$GITHUB_STEP_SUMMARY"
 
-      - name: Upload cell category
+      - name: Upload job status
         if: always()
         uses: actions/upload-artifact@v4
         with:
-          name: category-${{ inputs.distro }}-${{ matrix.gpu_config.gpu_target }}-${{ matrix.install_method }}
-          path: cell-category.txt
+          name: status-${{ inputs.distro }}-${{ matrix.gpu_config.gpu_target }}-${{ matrix.install_method }}
+          path: job-status.txt
 
       - name: Clean the workspace
         if: always()

--- a/.github/workflows/quartz_test.yml
+++ b/.github/workflows/quartz_test.yml
@@ -131,9 +131,10 @@ jobs:
 
   collect:
     needs: [gate, test]
-    # Read each test cell's self-reported category and take the worst: any genuine
-    # build/test break -> "bug"; else any transient infra failure -> "infra"; else
-    # "success". record uses this to decide record-and-stop vs leave-unrecorded-to-retry.
+    # Read each cell's self-reported category and retry until infra is healthy: any
+    # cell with an infra failure (install/env) -> "infra" (retry the whole version);
+    # else any genuine build/test break -> "bug" (record & stop); else "success".
+    # record uses this to decide record-and-stop vs leave-unrecorded-to-retry.
     if: always() && needs.gate.outputs.is_new == 'true' && needs.test.result != 'skipped'
     runs-on: ubuntu-24.04
     permissions:
@@ -144,21 +145,23 @@ jobs:
     outputs:
       category: ${{ steps.eval.outputs.category }}
     steps:
-      - name: Download cell categories
+      - name: Download job status
         uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
         with:
-          pattern: category-*
-          path: cats
+          pattern: status-*
+          path: status
 
       - name: Aggregate categories
         id: eval
         run: |
-          # Worst cell wins. No artifacts at all -> infra, so we retry rather than
-          # record a version we have no signal for.
-          if   grep -rqx bug     cats 2>/dev/null; then category=bug
-          elif grep -rqx infra   cats 2>/dev/null; then category=infra
-          elif grep -rqx success cats 2>/dev/null; then category=success
-          else                                          category=infra
+          # Infra wins: retry until infra is healthy. Any cell that hit an infra
+          # failure (install/env) -> retry the whole version; only once every cell's
+          # environment came up do we judge the build/test result. No artifacts at
+          # all -> infra, so we retry rather than record a version we have no signal for.
+          if   grep -rqx infra   status 2>/dev/null; then category=infra
+          elif grep -rqx bug     status 2>/dev/null; then category=bug
+          elif grep -rqx success status 2>/dev/null; then category=success
+          else                                            category=infra
           fi
           echo "category=$category" >> "$GITHUB_OUTPUT"
 

--- a/.github/workflows/quartz_test.yml
+++ b/.github/workflows/quartz_test.yml
@@ -129,17 +129,48 @@ jobs:
       tarballs_url: ${{ needs.gate.outputs.tarballs_url }}
     secrets: inherit
 
-  record:
+  collect:
     needs: [gate, test]
-    # Record ONLY on a green test run. Any failure -- transient infra (wheel-index
-    # outage, tarball 404, runner hiccup) OR a real build/test break -- leaves the
-    # version unrecorded so the next poll re-tests it, instead of masking it until
-    # the 7-day cache eviction. A failed run is never a conclusive "tested": we may
-    # simply have been unable to install. Retry is bounded -- a version is revisited
-    # only while it stays Quartz's latest-ready build, and the next nightly (which
-    # resolve() always prefers) supersedes it -- so a genuinely broken nightly costs
-    # at most the handful of polls in one morning window, not an hourly loop.
-    if: needs.test.result == 'success'
+    # Read each test cell's self-reported category and take the worst: any genuine
+    # build/test break -> "bug"; else any transient infra failure -> "infra"; else
+    # "success". record uses this to decide record-and-stop vs leave-unrecorded-to-retry.
+    if: always() && needs.gate.outputs.is_new == 'true' && needs.test.result != 'skipped'
+    runs-on: ubuntu-24.04
+    permissions:
+      actions: read
+    defaults:
+      run:
+        shell: bash
+    outputs:
+      category: ${{ steps.eval.outputs.category }}
+    steps:
+      - name: Download cell categories
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
+        with:
+          pattern: category-*
+          path: cats
+
+      - name: Aggregate categories
+        id: eval
+        run: |
+          # Worst cell wins. No artifacts at all -> infra, so we retry rather than
+          # record a version we have no signal for.
+          if   grep -rqx bug     cats 2>/dev/null; then category=bug
+          elif grep -rqx infra   cats 2>/dev/null; then category=infra
+          elif grep -rqx success cats 2>/dev/null; then category=success
+          else                                          category=infra
+          fi
+          echo "category=$category" >> "$GITHUB_OUTPUT"
+
+  record:
+    needs: [gate, test, collect]
+    # Record when the run is conclusive: a clean pass, OR a genuine build/test break
+    # (retrying won't fix broken examples -- mark tested so we stop re-running it, and
+    # surface it below). A transient infra failure (wheel-index outage, tarball 404,
+    # runner hiccup) stays unrecorded so the next poll re-tests it. Retry is bounded --
+    # a version is revisited only while it stays Quartz's latest-ready build, and the
+    # next nightly (which resolve() always prefers) supersedes it.
+    if: needs.test.result == 'success' || needs.collect.outputs.category == 'bug'
     runs-on: ubuntu-24.04
     defaults:
       run:
@@ -156,7 +187,11 @@ jobs:
 
       - name: Summary
         run: |
-          echo "Recorded ROCm ${{ needs.gate.outputs.rocm_version }} (${{ needs.gate.outputs.build_date }}) as tested (passed)." >> "$GITHUB_STEP_SUMMARY"
+          if [ "${{ needs.test.result }}" = "success" ]; then
+            echo "Recorded ROCm ${{ needs.gate.outputs.rocm_version }} (${{ needs.gate.outputs.build_date }}) as tested (passed)." >> "$GITHUB_STEP_SUMMARY"
+          else
+            echo "::warning::Recorded ROCm ${{ needs.gate.outputs.rocm_version }} (${{ needs.gate.outputs.build_date }}) as tested (GENUINE build/test break -- will not retry). Investigate." >> "$GITHUB_STEP_SUMMARY"
+          fi
 
   report:
     needs: gate

--- a/.github/workflows/quartz_test.yml
+++ b/.github/workflows/quartz_test.yml
@@ -131,8 +131,8 @@ jobs:
 
   collect:
     needs: [gate, test]
-    # Read each cell's self-reported category and retry until infra is healthy: any
-    # cell with an infra failure (install/env) -> "infra" (retry the whole version);
+    # Read each matrix job's self-reported category and retry until infra is healthy: any
+    # matrix job with an infra failure (install/env) -> "infra" (retry the whole version);
     # else any genuine build/test break -> "bug" (record & stop); else "success".
     # record uses this to decide record-and-stop vs leave-unrecorded-to-retry.
     if: always() && needs.gate.outputs.is_new == 'true' && needs.test.result != 'skipped'
@@ -154,8 +154,8 @@ jobs:
       - name: Aggregate categories
         id: eval
         run: |
-          # Infra wins: retry until infra is healthy. Any cell that hit an infra
-          # failure (install/env) -> retry the whole version; only once every cell's
+          # Infra wins: retry until infra is healthy. Any matrix job that hit an infra
+          # failure (install/env) -> retry the whole version; only once every matrix job's
           # environment came up do we judge the build/test result. No artifacts at
           # all -> infra, so we retry rather than record a version we have no signal for.
           if   grep -rqx infra   status 2>/dev/null; then category=infra
@@ -165,6 +165,17 @@ jobs:
           fi
           echo "category=$category" >> "$GITHUB_OUTPUT"
 
+      - name: Report verdict
+        run: |
+          # record itself reports the success/bug cases; the infra verdict is not
+          # recorded by any downstream job, so surface here that it will be retried.
+          ver="ROCm ${{ needs.gate.outputs.rocm_version }} (${{ needs.gate.outputs.build_date }})"
+          case "${{ steps.eval.outputs.category }}" in
+            infra) echo "::notice::${ver}: infra failure (install/env) -- left unrecorded, will be retried on the next poll." >> "$GITHUB_STEP_SUMMARY" ;;
+            bug)   echo "${ver}: genuine build/test break -- recording (no retry)." >> "$GITHUB_STEP_SUMMARY" ;;
+            *)     echo "${ver}: all matrix jobs passed." >> "$GITHUB_STEP_SUMMARY" ;;
+          esac
+
   record:
     needs: [gate, test, collect]
     # Record when the run is conclusive: a clean pass, OR a genuine build/test break
@@ -173,7 +184,16 @@ jobs:
     # runner hiccup) stays unrecorded so the next poll re-tests it. Retry is bounded --
     # a version is revisited only while it stays Quartz's latest-ready build, and the
     # next nightly (which resolve() always prefers) supersedes it.
-    if: needs.test.result == 'success' || needs.collect.outputs.category == 'bug'
+    #
+    # always() is required: without a status function a failed/skipped `collect` would
+    # skip `record` outright, even on an all-green matrix, since GitHub gates a job on
+    # its `needs` succeeding unless the `if` opts out. With always(), an all-green run
+    # still records via test.result == 'success' (collect's empty category just makes the
+    # second clause false), and skip cases stay skipped (test skipped/cancelled, no category).
+    if: >-
+      always()
+      && needs.gate.outputs.is_new == 'true'
+      && (needs.test.result == 'success' || needs.collect.outputs.category == 'bug')
     runs-on: ubuntu-24.04
     defaults:
       run:


### PR DESCRIPTION
## Motivation

The Quartz nightly test marks a whole run `failure` without distinguishing a
transient infra problem (an unpublished wheel, a tarball 404, a runner hiccup)
from a genuine build/test break. Both cases are treated the same: the version is
never recorded, so the full self-hosted GPU matrix re-runs every 2h poll — even
when the failure is a real, permanent break that retrying can never fix.

Last night (ROCm 10.1.0a20260909) is a textbook case: every `whl-multi-arch`
matrix job died at install with `No matching distribution found for rocm==10.1.0a20260909`
(the wheel simply wasn't published yet — pure infra), while a couple of matrix
jobs that installed fine hit genuine breaks (`libavcodec.so.58` missing, `rocgdb`
ctest failures). Today's workflow can't tell these apart.

## Technical Details

Each matrix job now self-reports a category (`infra` / `bug` / `success`) as an
uploaded artifact, and a `collect` job aggregates them to drive the
record-vs-retry decision:

- **Per-job classification** (`build-rocm-examples-reusable.yml`): an
  `Environment status check` step flags checkout/install/env-setup failures — and
  the wheel sanity check — as transient. Build and test steps are gated with
  `!cancelled()` so the CMake and Make chains fail-fast **independently** rather
  than cascading. `Classify outcome` then emits `infra` (env/install broke, or an
  artifact upload failed), `bug` (a build/test step failed), or `success`,
  uploaded as `status-<distro>-<gpu>-<install_method>`. The artifact body carries
  the bare category on its first line (so `collect` can match it with `grep -qx`)
  followed by the resolved `rocm_version` and `install_url`.
- **Aggregation is infra-dominates** (`quartz_test.yml` `collect` job): if **any**
  matrix job hit an infra failure, the whole version is `infra` and is left
  unrecorded so the next poll retries it — i.e. **retry until infra is healthy**.
  Only once every matrix job's environment came up does a genuine build/test
  break settle it as `bug`. `collect` also reports the verdict to the run summary,
  including the `infra` (will-be-retried) case that no other job surfaces.
- **`record`** writes the dedup marker on a clean pass **or** a `bug` (retrying
  won't fix broken examples — mark tested, stop re-running, surface a warning).
  An `infra` verdict stays unrecorded. It is guarded with `always()` so a failed
  or skipped `collect` cannot skip recording an all-green matrix. Retry is
  bounded: a version is only revisited while it stays Quartz's latest-ready build,
  and the next nightly supersedes it.

Also includes naming cleanup of the per-job status plumbing
(`prep`→`environment-status`, `mk-build`/`mk-test`→`make-build`/`make-test`,
`cell-category`/`category-*`→`job-status`/`status-*`), gates `Run tests` on
`cmake-build` instead of `cmake-install`, corrects a stale comment that
mis-attributed the per-job classification to the `collect` job (it is done by the
local `Classify outcome` step), and pins `actions/checkout` and
`actions/upload-artifact` to commit SHAs. (Pinning the remaining tag-pinned
workflows and adding a `check-gha-pinning` pre-commit hook to enforce it is left
to a follow-up PR.)

## Test Plan

- YAML + actionlint validated for both workflows.
- Logic traced against last night's real matrix (run 34300488752): whl/tarball
  install failures → `infra` (dominates) → version stays unrecorded and retries;
  once installs are healthy, the `libavcodec`/`rocgdb` breaks would classify
  `bug` → record + warn.

## Test Result

Full end-to-end behavior is exercised by the scheduled nightly against the next
ready Quartz build; not runnable ad hoc here.

## Added/Updated documentation?

- [ ] Yes
- [x] No, does not apply to this PR.

## Included Visual Studio files?

- [ ] Yes
- [x] No, does not apply to this PR.

## Submission Checklist

- [ ] New examples contain proper CMake and Make files.
- [x] I have updated relevant CI workflows and the new examples are being built and tested in CI.
- [ ] Check and guard against unsupported ASICs if relevant dependent libraries have limited support.
- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
