### PR TITLE
fix(rocDecode): register FFmpeg in loader cache on SLES/AlmaLinux multiarch images

### DIFF
--- a/Dockerfiles/almalinux-8-multiarch.Dockerfile
+++ b/Dockerfiles/almalinux-8-multiarch.Dockerfile
@@ -114,7 +114,11 @@ ENV LD_LIBRARY_PATH="${VULKAN_SDK}/lib:${LD_LIBRARY_PATH}"
 ENV VK_ADD_LAYER_PATH="${VULKAN_SDK}/share/vulkan/explicit_layer.d"
 ENV PKG_CONFIG_PATH="${VULKAN_SDK}/share/pkgconfig:${VULKAN_SDK}/lib/pkgconfig:/usr/local/lib/pkgconfig:/usr/local/lib64/pkgconfig"
 
-# Build FFmpeg from source (not available in RHEL 8 repos)
+# Build FFmpeg from source (not available in RHEL 8 repos). FFmpeg installs into
+# /usr/local/lib, which RHEL 8's ldconfig does not search by default (unlike SLES,
+# whose /etc/ld.so.conf lists it), so register it before ldconfig -- otherwise
+# libavcodec.so.58 stays out of the loader cache and rocDecode's Makefile test
+# fails at runtime with "error while loading shared libraries".
 WORKDIR /tmp
 RUN wget https://ffmpeg.org/releases/ffmpeg-4.4.6.tar.xz && \
     tar -xvf ffmpeg-4.4.6.tar.xz && \
@@ -122,6 +126,7 @@ RUN wget https://ffmpeg.org/releases/ffmpeg-4.4.6.tar.xz && \
     ./configure --enable-pic --enable-shared && \
     make -j$(nproc) && \
     make install && \
+    echo "/usr/local/lib" > /etc/ld.so.conf.d/local.conf && \
     ldconfig && \
     rm -rf /tmp/ffmpeg-4.4.6*
 

--- a/Dockerfiles/sles-15.7-multiarch.Dockerfile
+++ b/Dockerfiles/sles-15.7-multiarch.Dockerfile
@@ -124,6 +124,7 @@ RUN wget https://ffmpeg.org/releases/ffmpeg-4.4.6.tar.xz && \
     ./configure --enable-pic --enable-shared && \
     make -j$(nproc) && \
     make install && \
+    ldconfig && \
     rm -rf /tmp/ffmpeg-4.4.6*
 
 ENV HIP_PLATFORM=amd


### PR DESCRIPTION
## Summary
FFmpeg is built from source into `/usr/local/lib` on both the SLES 15.7 and AlmaLinux 8 multiarch images, but the loader cache was never regenerated, so `libavcodec.so.58` was unresolvable at runtime. rocDecode's Makefile-built examples link FFmpeg with no RPATH, so `make test` failed with `error while loading shared libraries: libavcodec.so.58`. (ctest passes because CMake embeds a build-tree RPATH to the full-path-linked FFmpeg.)

- **SLES**: add the missing `ldconfig` after `make install` — `/etc/ld.so.conf` already lists `/usr/local/lib`, so regenerating the cache is sufficient.
- **AlmaLinux**: RHEL 8's `ldconfig` does not search `/usr/local/lib` by default and the existing `ldconfig` was a no-op for FFmpeg. Register `/usr/local/lib` via `/etc/ld.so.conf.d/local.conf` before `ldconfig`.

The AlmaLinux failure was previously **masked** in CI because `make test` aborted earlier at `rocProfiler-SDK/api_buffered_tracing`; now that #514 fixed that, `make test` reaches rocDecode and would fail without this change.

## Test plan
Full suite (Makefile build → CMake configure/build/install → ctest → Makefile test) run locally on both gfx1100 multiarch images against the ROCm 10.1 nightly tarball:

- [x] SLES 15.7: `makefile_build=0 cmake_configure=0 cmake_build=0 cmake_install=0 ctest=0 (537/537) makefile_test=0`, zero loader errors
- [x] AlmaLinux 8: reproduced the `libavcodec.so.58` failure pre-fix; green post-fix
- [x] rocDecode `rocdec_decode` Makefile test runs (`./rocdecode_rocdec_decode -i .../frames`) with no loader error on both images

🤖 Generated with [Claude Code](https://claude.com/claude-code)